### PR TITLE
Add version option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 openstack-exporter
+vendor
 
 # Test binary, build with `go test -c`
 *.test

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,15 +1,24 @@
 go:
     # Whenever the Go version is updated here, .circle/config.yml should also
     # be updated.
-    version: 1.11
+    version: 1.13
+
 repository:
-    path: github.com/openstack-exporter/openstack-exporter
+  path: github.com/openstack-exporter/openstack-exporter
+
 build:
-    flags: -mod=vendor
+  ldflags: |
+    -X github.com/prometheus/common/version.Version={{.Version}}
+    -X github.com/prometheus/common/version.Revision={{.Revision}}
+    -X github.com/prometheus/common/version.Branch={{.Branch}}
+    -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+    -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+
 tarball:
-    files:
-        - LICENSE
+  files:
+    - LICENSE
+
 crossbuild:
-    platforms:
-        - linux/amd64
-        - linux/arm64
+  platforms:
+    - linux/amd64
+    - linux/arm64

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		services[service] = kingpin.Flag(flagName, flagHelp).Default().Bool()
 	}
 
+	kingpin.Version(version.Print("openstack-exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 


### PR DESCRIPTION
This adds a version option and also corrects the promu
golang version, as we've been shipping with golang 1.13

```
openstack-exporter, version 0.8.0 (branch: add-version, revision: c1f293c7a6e377d69a1e76eda7b584c5bebb99fe)
  build user:       mnaser@debian
  build date:       20191209-00:53:09
  go version:       go1.13.5
```